### PR TITLE
Add token parsers

### DIFF
--- a/parser/ethereum.py
+++ b/parser/ethereum.py
@@ -1,1 +1,31 @@
-# Ethereum parser logic
+# parser/ethereum.py
+
+"""Fetches new Ethereum tokens using :mod:`parser.token_fetcher`."""
+
+from typing import List, Dict
+
+from utils.logger import logger
+from .token_fetcher import fetch_new_tokens
+
+
+def get_new_tokens() -> List[Dict]:
+    """Return a list of newly discovered Ethereum tokens.
+
+    The function delegates the heavy lifting to :func:`fetch_new_tokens` and
+    wraps the call with error handling and logging.
+
+    Returns
+    -------
+    List[Dict]
+        A list of token dictionaries in the unified schema or an empty list on
+        failure.
+    """
+
+    try:
+        tokens = fetch_new_tokens("ethereum")
+        logger.info(f"[ethereum parser] Retrieved {len(tokens)} tokens")
+        return tokens
+    except Exception as exc:
+        logger.error(f"[ethereum parser] Failed to fetch tokens: {exc}")
+        return []
+

--- a/parser/solana.py
+++ b/parser/solana.py
@@ -1,1 +1,31 @@
-# Solana parser logic
+# parser/solana.py
+
+"""Fetches new Solana tokens using :mod:`parser.token_fetcher`."""
+
+from typing import List, Dict
+
+from utils.logger import logger
+from .token_fetcher import fetch_new_tokens
+
+
+def get_new_tokens() -> List[Dict]:
+    """Return a list of newly discovered Solana tokens.
+
+    The function calls :func:`fetch_new_tokens` with the ``solana`` chain and
+    logs errors if something goes wrong.
+
+    Returns
+    -------
+    List[Dict]
+        A list of token dictionaries in the unified schema or an empty list on
+        failure.
+    """
+
+    try:
+        tokens = fetch_new_tokens("solana")
+        logger.info(f"[solana parser] Retrieved {len(tokens)} tokens")
+        return tokens
+    except Exception as exc:
+        logger.error(f"[solana parser] Failed to fetch tokens: {exc}")
+        return []
+


### PR DESCRIPTION
## Summary
- implement `get_new_tokens` wrappers for Ethereum and Solana
- use existing `fetch_new_tokens` with logging

## Testing
- `python -m py_compile parser/ethereum.py parser/solana.py parser/token_fetcher.py`

------
https://chatgpt.com/codex/tasks/task_e_684d68a39b88832eaa327e7068ceb291