### PR TITLE
Implement memecoin filters and update tests

### DIFF
--- a/reputation_checker.py
+++ b/reputation_checker.py
@@ -2,11 +2,12 @@
 
 import os
 import requests
+from typing import Optional
 from utils.logger import logger
 
 ETHERSCAN_API_KEY = os.getenv("ETHERSCAN_API_KEY")
 
-def is_token_valid(token: dict) -> bool:
+def is_token_valid(token: dict, min_reputation_score: Optional[int] = None) -> bool:
     """
     Checks if a token's deployer is reputable based on Etherscan data.
     Currently applies only to Ethereum tokens.
@@ -25,8 +26,12 @@ def is_token_valid(token: dict) -> bool:
 
     score = get_deployer_reputation(deployer)
     logger.info(f"[Reputation] {deployer} scored {score}/10")
-    
-    min_score = int(os.getenv("MIN_REPUTATION_SCORE", "5"))
+
+    if min_reputation_score is None:
+        min_score = int(os.getenv("MIN_REPUTATION_SCORE", "5"))
+    else:
+        min_score = int(min_reputation_score)
+
     return score >= min_score
 
 def get_deployer_reputation(address: str) -> int:

--- a/tests/test_generate_content.py
+++ b/tests/test_generate_content.py
@@ -15,17 +15,46 @@ setattr(matplotlib, "pyplot", plt)
 sys.modules.setdefault("matplotlib", matplotlib)
 sys.modules.setdefault("matplotlib.pyplot", plt)
 
+# Minimal YAML stub for config loading
+yaml_mod = types.ModuleType("yaml")
+def _safe_load(stream):
+    return {
+        "filters": {
+            "min_liquidity_usd": 2000,
+            "min_volume_1h_usd": 1000,
+            "min_token_age_minutes": 10,
+            "blacklist_tokens": ["scam"],
+            "min_reputation_score": 5,
+        }
+    }
+yaml_mod.safe_load = lambda s: _safe_load(s)
+sys.modules.setdefault("yaml", yaml_mod)
+
 # Stub internal modules that rely on external services
 fetcher = types.ModuleType("token_fetcher")
-fetcher.fetch_new_tokens = lambda chain: []
+sample_tokens = [
+    {"ticker": "GOOD", "liquidity": 3000, "volume_30m": 2000, "age_minutes": 20, "chain": "solana"},
+    {"ticker": "BADSCAM", "liquidity": 3000, "volume_30m": 2000, "age_minutes": 20, "chain": "solana"},
+    {"ticker": "LOWVOL", "liquidity": 3000, "volume_30m": 500, "age_minutes": 20, "chain": "solana"},
+    {"ticker": "YOUNG", "liquidity": 3000, "volume_30m": 2000, "age_minutes": 5, "chain": "solana"},
+    {"ticker": "LOWLIQ", "liquidity": 1000, "volume_30m": 2000, "age_minutes": 20, "chain": "solana"},
+]
+fetcher.fetch_new_tokens = lambda chain: sample_tokens
 sys.modules["parser.token_fetcher"] = fetcher
 
 reputation = types.ModuleType("reputation_checker")
-reputation.is_token_valid = lambda token: True
+called_scores = []
+def _is_valid(token, min_score=None):
+    called_scores.append(min_score)
+    return True
+reputation.is_token_valid = _is_valid
 sys.modules["reputation_checker"] = reputation
 
 poster_mod = types.ModuleType("poster")
-poster_mod.queue_for_zenno = lambda *a, **k: None
+posted = []
+def _queue(bot_name, filename, text, base_folder="output"):
+    posted.append({"bot": bot_name, "filename": filename, "text": text})
+poster_mod.queue_for_zenno = _queue
 sys.modules["poster"] = poster_mod
 
 logger_mod = types.ModuleType("logger")
@@ -34,10 +63,24 @@ logger_mod.logger = types.SimpleNamespace(info=lambda *a, **k: None,
                                           error=lambda *a, **k: None)
 sys.modules["utils.logger"] = logger_mod
 
-from generate_content import sanitize_filename_component
+from generate_content import sanitize_filename_component, generate_and_queue_memecoin_tweet
 
 
 def test_sanitize_filename_component():
     text = "token name$%_.123"
     result = sanitize_filename_component(text)
     assert result == "tokenname_123"
+
+
+def test_generate_and_queue_memecoin_tweet_filters(tmp_path, monkeypatch):
+    # Ensure output folder is isolated
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "config.yaml").write_text("stub")
+
+    generate_and_queue_memecoin_tweet("bot1", chain="solana", top_n=3)
+
+    # Only one token should pass filters
+    assert len(posted) == 1
+    assert "GOOD" in posted[0]["filename"].upper()
+    # is_token_valid called with configured min score
+    assert called_scores == [5]


### PR DESCRIPTION
## Summary
- support YAML config in `generate_and_queue_memecoin_tweet` and filter tokens
- allow passing `min_reputation_score` to `is_token_valid`
- expand unit tests for memecoin filtering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f228d71ec832e8a0827f42715a3dc