### PR TITLE
Add draft mode and pending folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ Before running the bot, copy `.env.example` to `.env` and fill in your API keys 
   4. **Commentary/Meme** – A short, engaging remark or meme-style comment (.txt).  
 
 - **Queue for Posting**  
-  Generated files (.png and .txt) are placed into output/{bot_name}/. A separate engine (e.g. ZennoPoster) can pick them up and publish them on Twitter in a human-like way.
+  Generated files (.png and .txt) are placed into `output/{bot_name}/`.
+  If `BOT_MODE` is set to `draft` and Telegram credentials are provided,
+  they go to `pending/{bot_name}/` instead and you receive a Telegram
+  notification. A separate engine (e.g. ZennoPoster) can pick them up
+  after approval.
 
 - **Multi-Account Support**  
   Designed to rotate posts across multiple Twitter/X accounts. Each account simply has its own subfolder under output/ (e.g. output/solana_bot_1/, output/eth_bot_2/).
@@ -125,7 +129,8 @@ INFURA_API_KEY=your_infura_api_key
 ETHERSCAN_API_KEY=your_etherscan_api_key
 
 # ----- Bot Behavior Settings -----
-BOT_MODE=post                    # "post" → publish via ZennoPoster, "draft" → save locally
+BOT_MODE=post                    # "post" → publish via ZennoPoster
+                                # "draft" → save to pending/ and notify Telegram
 SCHEDULE_INTERVAL=300            # In seconds (300 = 5 minutes)
 LOG_LEVEL=info                   # Fallback logging level if not set in config.yaml
 
@@ -375,7 +380,8 @@ If you prefer manual oversight:
 bash
    python telegram_bot.py
 
-2. Whenever generate_content.py places a new *.txt into pending/{bot_name}/, the bot sends you a message with inline buttons:
+2. Whenever `generate_content.py` places a new file into `pending/{bot_name}/`
+   (this happens when `BOT_MODE=draft`), the bot sends you a message with inline buttons:
    
 🆕 New post ready for solana_bot_1:
    pending/solana_bot_1/memecoin_20250606_1230.txt

--- a/generate_content.py
+++ b/generate_content.py
@@ -8,6 +8,12 @@ from parser.token_fetcher import fetch_new_tokens
 from reputation_checker import is_token_valid
 from poster import queue_for_zenno
 from utils.logger import logger
+from utils.settings import get_bot_mode, get_output_base_folder, has_telegram
+try:
+    from telegram_bot import notify_pending  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    def notify_pending(*_args, **_kwargs):
+        pass
 
 
 def generate_and_queue_chart(bot_name):
@@ -29,11 +35,16 @@ def generate_and_queue_chart(bot_name):
     plt.tight_layout()
 
     filename = datetime.now().strftime("chart_%Y%m%d_%H%M.png")
-    out_path = os.path.join("output", bot_name, filename)
+    base_folder = get_output_base_folder()
+    if get_bot_mode() == "draft" and has_telegram():
+        base_folder = "pending"
+    out_path = os.path.join(base_folder, bot_name, filename)
     os.makedirs(os.path.dirname(out_path), exist_ok=True)
     plt.savefig(out_path)
     plt.close()
     logger.info(f"[{bot_name}] Chart saved: {out_path}")
+    if base_folder == "pending":
+        notify_pending(bot_name, out_path)
 
 
 def generate_and_queue_exchange_info(bot_name):

--- a/poster.py
+++ b/poster.py
@@ -1,15 +1,25 @@
 # poster.py
 
 import os
-from datetime import datetime
 from utils.logger import logger
+from utils.settings import (
+    get_bot_mode,
+    get_output_base_folder,
+    has_telegram,
+)
+from telegram_bot import notify_pending
 
-def queue_for_zenno(bot_name, filename, text, base_folder="output"):
+def queue_for_zenno(bot_name, filename, text, base_folder=None):
     """
     Saves a .txt file to output/{bot_name}/{filename}.
     ZennoPoster will monitor this folder to post the content.
     """
     try:
+        if base_folder is None:
+            base_folder = get_output_base_folder()
+        if get_bot_mode() == "draft" and has_telegram():
+            base_folder = "pending"
+
         folder = os.path.join(base_folder, bot_name)
         os.makedirs(folder, exist_ok=True)
 
@@ -18,5 +28,7 @@ def queue_for_zenno(bot_name, filename, text, base_folder="output"):
             f.write(text.strip())
 
         logger.info(f"[{bot_name}] ✅ Queued for ZennoPoster: {filepath}")
+        if base_folder == "pending":
+            notify_pending(bot_name, filepath)
     except Exception as e:
         logger.error(f"[{bot_name}] ❌ Failed to queue file {filename}: {e}")

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -1,0 +1,33 @@
+import os
+try:
+    import yaml
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None
+
+_config_cache = None
+
+def _load_config():
+    global _config_cache
+    if _config_cache is None:
+        try:
+            if yaml is None:
+                raise ImportError
+            with open("config.yaml", "r", encoding="utf-8") as f:
+                _config_cache = yaml.safe_load(f) or {}
+        except Exception:
+            _config_cache = {}
+    return _config_cache
+
+def get_bot_mode() -> str:
+    cfg = _load_config()
+    return os.getenv("BOT_MODE") or cfg.get("bot_mode", "post")
+
+def get_output_base_folder() -> str:
+    cfg = _load_config()
+    return cfg.get("output", {}).get("base_folder", "output")
+
+def has_telegram() -> bool:
+    cfg = _load_config()
+    token = os.getenv("TELEGRAM_BOT_TOKEN") or cfg.get("telegram", {}).get("bot_token")
+    chat_id = os.getenv("TELEGRAM_CHAT_ID") or str(cfg.get("telegram", {}).get("admin_chat_id"))
+    return bool(token) and bool(chat_id) and chat_id != "0"


### PR DESCRIPTION
## Summary
- support draft mode by checking environment or config and sending results to `pending/`
- create utility helpers for reading settings
- make content generators and poster aware of pending folder
- document new behavior in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f2292ef50832ebdb1ebcd2eb3b0c9