### PR TITLE
Add ignores for temp directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,9 @@ state.json
 
 # Mac system files
 .DS_Store
+
+# Temporary and log outputs
+pending/
+output/
+logs/
+state.json


### PR DESCRIPTION
## Summary
- update `.gitignore` to ensure temporary directories and `state.json` are excluded

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'telegram')*

------
https://chatgpt.com/codex/tasks/task_e_684f2a75cacc832e9f709a5c4ce592e7