### PR TITLE
Add token fetcher module and tests

### DIFF
--- a/parser/__init__.py
+++ b/parser/__init__.py
@@ -1,0 +1,4 @@
+from . import token_fetcher
+from .token_fetcher import fetch_new_tokens
+
+__all__ = ["fetch_new_tokens", "token_fetcher"]

--- a/parser/token_fetcher.py
+++ b/parser/token_fetcher.py
@@ -1,0 +1,53 @@
+import requests
+from typing import List, Dict, Any
+
+from utils.logger import logger
+
+
+def fetch_new_tokens(chain: str) -> List[Dict[str, Any]]:
+    """Fetch recently created tokens on the given chain.
+
+    The function queries a public API such as Dexscreener or Birdeye and
+    normalises the response into a list of dictionaries with the fields
+    documented in the README.
+    """
+    chain_l = chain.lower()
+
+    if chain_l == "solana":
+        url = "https://public-api.birdeye.so/defi/trending"
+        params = {"timeRange": "30m", "chain": "solana"}
+    elif chain_l == "ethereum":
+        url = "https://api.dexscreener.com/latest/dex/tokens/ethereum"
+        params = {"sort": "txns30m"}
+    else:
+        raise ValueError(f"Unsupported chain: {chain}")
+
+    try:
+        resp = requests.get(url, params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:  # pragma: no cover - network failures
+        logger.error(f"Failed to fetch tokens for {chain}: {exc}")
+        return []
+
+    raw_tokens = data.get("data") or data.get("tokens") or []
+
+    tokens: List[Dict[str, Any]] = []
+    for item in raw_tokens:
+        token = {
+            "ticker": item.get("symbol")
+            or item.get("tokenSymbol")
+            or item.get("baseTokenSymbol"),
+            "liquidity": item.get("liquidity") or item.get("liquidityInUsd"),
+            "volume_30m": item.get("volume_30m") or item.get("volume30m"),
+            "age_minutes": item.get("age_minutes")
+            or item.get("ageMinutes")
+            or item.get("age"),
+            "contract_address": item.get("address")
+            or item.get("tokenAddress")
+            or item.get("baseTokenAddress"),
+            "deployer": item.get("deployer") or item.get("creator") or "unknown",
+        }
+        tokens.append(token)
+
+    return tokens

--- a/tests/test_token_fetcher.py
+++ b/tests/test_token_fetcher.py
@@ -1,0 +1,75 @@
+import os
+import sys
+import types
+
+# Add project root to sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Stub logger to avoid file writes during import
+logger_mod = types.ModuleType("logger")
+logger_mod.logger = types.SimpleNamespace(info=lambda *a, **k: None, error=lambda *a, **k: None)
+sys.modules.setdefault("utils.logger", logger_mod)
+
+# Stub requests so parser.token_fetcher imports without the real library
+requests_mod = types.ModuleType("requests")
+requests_mod.get = lambda *a, **k: None
+sys.modules.setdefault("requests", requests_mod)
+
+# Ensure the real module is imported
+sys.modules.pop("parser.token_fetcher", None)
+
+from parser import token_fetcher
+from parser.token_fetcher import fetch_new_tokens
+
+
+class DummyResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        pass
+
+
+def test_fetch_new_tokens_parses(monkeypatch):
+    payload = {
+        "data": [
+            {
+                "symbol": "AAA",
+                "liquidity": 1000,
+                "volume_30m": 500,
+                "age_minutes": 12,
+                "address": "0x1",
+                "deployer": "0xD1",
+            }
+        ]
+    }
+
+    def fake_get(url, params=None, timeout=10):
+        return DummyResponse(payload)
+
+    monkeypatch.setattr(token_fetcher.requests, "get", fake_get)
+    tokens = fetch_new_tokens("solana")
+
+    assert tokens == [
+        {
+            "ticker": "AAA",
+            "liquidity": 1000,
+            "volume_30m": 500,
+            "age_minutes": 12,
+            "contract_address": "0x1",
+            "deployer": "0xD1",
+        }
+    ]
+
+
+def test_fetch_new_tokens_error(monkeypatch):
+    def fake_get(*_a, **_k):
+        raise Exception("boom")
+
+    monkeypatch.setattr(token_fetcher.requests, "get", fake_get)
+    tokens = fetch_new_tokens("ethereum")
+    assert tokens == []
+


### PR DESCRIPTION
## Summary
- implement `parser.token_fetcher.fetch_new_tokens` that queries public APIs and
  returns token info fields described in the README
- make `parser` a package
- add unit tests for the new function with mocked requests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f3029100c832ea935fdb79042802a