### PR TITLE
Fix duplicate ignore lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,3 @@ state.json
 # Mac system files
 .DS_Store
 
-# Temporary and log outputs
-pending/
-output/
-logs/
-state.json


### PR DESCRIPTION
## Summary
- remove redundant ignore entries

## Testing
- `grep -n output/ .gitignore`
- `grep -n pending/ .gitignore`
- `grep -n logs/ .gitignore`
- `grep -n state.json .gitignore`

------
https://chatgpt.com/codex/tasks/task_e_684f302fb6e8832e94433a03c4740776