### PR TITLE
Refactor config loading to use shared cache

### DIFF
--- a/generate_content.py
+++ b/generate_content.py
@@ -3,13 +3,17 @@ from datetime import datetime
 import random
 from pycoingecko import CoinGeckoAPI
 import matplotlib.pyplot as plt
-import yaml
 
 from parser.token_fetcher import fetch_new_tokens
 from reputation_checker import is_token_valid
 from poster import queue_for_zenno
 from utils.logger import logger
-from utils.settings import get_bot_mode, get_output_base_folder, has_telegram
+from utils.settings import (
+    get_bot_mode,
+    get_output_base_folder,
+    has_telegram,
+    get_config,
+)
 try:
     from telegram_bot import notify_pending  # type: ignore
 except Exception:  # pragma: no cover - optional dependency
@@ -70,11 +74,12 @@ def generate_and_queue_memecoin_tweet(bot_name, chain="solana", top_n=3):
     logger.info(f"[{bot_name}] Fetching memecoins on {chain}")
 
     try:
-        with open("config.yaml", "r", encoding="utf-8") as f:
-            config = yaml.safe_load(f)
+        config = get_config()
         filters = config.get("filters", {})
     except Exception as e:
-        logger.error(f"[{bot_name}] Failed to load filters from config.yaml: {e}")
+        logger.error(
+            f"[{bot_name}] Failed to load filters from config.yaml: {e}"
+        )
         filters = {}
 
     min_liq = filters.get("min_liquidity_usd", 0)

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@
 import os
 import json
 from dotenv import load_dotenv
-import yaml
+from utils.settings import get_config
 
 from utils.logger import logger
 from generate_content import (
@@ -25,8 +25,8 @@ DEFAULT_CONTENT_CYCLE = [
 STATE_FILE = "state.json"
 
 def load_config():
-    with open("config.yaml", "r", encoding="utf-8") as f:
-        return yaml.safe_load(f)
+    """Return bot configuration."""
+    return get_config()
 
 def get_next_content_type(content_cycle):
     if not os.path.exists(STATE_FILE):

--- a/scheduler.py
+++ b/scheduler.py
@@ -2,13 +2,13 @@ import time
 import schedule
 from dotenv import load_dotenv
 from main import main
-import yaml
 from utils.logger import logger
+from utils.settings import get_config
 
 def get_interval_from_config():
+    """Return scheduler interval from config."""
     try:
-        with open("config.yaml", "r", encoding="utf-8") as f:
-            config = yaml.safe_load(f)
+        config = get_config()
         return config.get("scheduler", {}).get("interval_seconds", 300)
     except Exception as e:
         logger.error(f"Failed to load schedule interval from config.yaml: {e}")

--- a/tests/test_generate_content.py
+++ b/tests/test_generate_content.py
@@ -30,6 +30,9 @@ def _safe_load(stream):
 yaml_mod.safe_load = lambda s: _safe_load(s)
 sys.modules.setdefault("yaml", yaml_mod)
 
+import utils.settings as settings
+settings._config_cache = None
+
 # Stub internal modules that rely on external services
 fetcher = types.ModuleType("token_fetcher")
 sample_tokens = [

--- a/tests/test_generate_functions.py
+++ b/tests/test_generate_functions.py
@@ -18,6 +18,9 @@ setattr(matplotlib, "pyplot", plt)
 sys.modules.setdefault("matplotlib", matplotlib)
 sys.modules.setdefault("matplotlib.pyplot", plt)
 
+import utils.settings as settings
+settings._config_cache = None
+
 # Stub logger to avoid file writes
 logger_mod = types.ModuleType("logger")
 logger_mod.logger = types.SimpleNamespace(info=lambda *a, **k: None,
@@ -103,10 +106,7 @@ def test_generate_and_queue_memecoin_tweet(monkeypatch, tmp_path):
     monkeypatch.setattr(generate_content, "fetch_new_tokens", lambda c: tokens)
     monkeypatch.setattr(generate_content, "is_token_valid", lambda t, m=None: True)
 
-    def fake_open(*_a, **_k):
-        raise FileNotFoundError
-
-    monkeypatch.setattr(generate_content, "open", fake_open, raising=False)
+    monkeypatch.setattr(generate_content, "get_config", lambda: {})
 
     calls = []
 

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,6 +1,6 @@
 import os
 import logging
-import yaml
+from . import settings
 
 os.makedirs("logs", exist_ok=True)
 
@@ -8,8 +8,7 @@ os.makedirs("logs", exist_ok=True)
 def _get_log_level() -> str:
     """Determine log level from config.yaml or environment."""
     try:
-        with open("config.yaml", "r", encoding="utf-8") as f:
-            config = yaml.safe_load(f)
+        config = settings.get_config()
         level = config.get("logging", {}).get("level")
         if level:
             return level

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -6,6 +6,14 @@ except Exception:  # pragma: no cover - optional dependency
 
 _config_cache = None
 
+
+def get_config() -> dict:
+    """Return configuration loaded from ``config.yaml``.
+
+    The file is read only once and cached for subsequent calls.
+    """
+    return _load_config()
+
 def _load_config():
     global _config_cache
     if _config_cache is None:


### PR DESCRIPTION
## Summary
- expose `get_config()` in `utils.settings` to cache config data
- use the shared loader in `generate_content`, `main`, `scheduler`, and logger
- update tests to use the new helper and reset the cache

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f37b77c88832e9a1a0f353689eab3