### PR TITLE
Add chain information to tokens

### DIFF
--- a/parser/token_fetcher.py
+++ b/parser/token_fetcher.py
@@ -47,6 +47,7 @@ def fetch_new_tokens(chain: str) -> List[Dict[str, Any]]:
             or item.get("tokenAddress")
             or item.get("baseTokenAddress"),
             "deployer": item.get("deployer") or item.get("creator") or "unknown",
+            "chain": chain_l,
         }
         tokens.append(token)
 

--- a/tests/test_reputation_checker.py
+++ b/tests/test_reputation_checker.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import types
+
+# Add project root to sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Stub logger
+logger_mod = types.ModuleType("logger")
+logger_mod.logger = types.SimpleNamespace(info=lambda *a, **k: None,
+                                          warning=lambda *a, **k: None,
+                                          error=lambda *a, **k: None)
+sys.modules.setdefault("utils.logger", logger_mod)
+
+# Stub requests module so import works even if not installed
+requests_mod = types.ModuleType("requests")
+requests_mod.get = lambda *a, **k: None
+sys.modules.setdefault("requests", requests_mod)
+
+sys.modules.pop("reputation_checker", None)
+import reputation_checker
+
+
+def test_is_token_valid_skips_non_eth(monkeypatch):
+    called = []
+    monkeypatch.setattr(reputation_checker, "get_deployer_reputation",
+                        lambda addr: called.append(addr) or 10)
+
+    token = {"chain": "solana", "deployer": "0xD"}
+    assert reputation_checker.is_token_valid(token, min_reputation_score=5)
+    assert called == []
+
+
+def test_is_token_valid_checks_eth(monkeypatch):
+    called = []
+
+    def fake_rep(addr):
+        called.append(addr)
+        return 6
+
+    monkeypatch.setattr(reputation_checker, "get_deployer_reputation", fake_rep)
+
+    token = {"chain": "Ethereum", "deployer": "0xA"}
+    assert reputation_checker.is_token_valid(token, min_reputation_score=5)
+    assert called == ["0xA"]

--- a/tests/test_token_fetcher.py
+++ b/tests/test_token_fetcher.py
@@ -61,6 +61,7 @@ def test_fetch_new_tokens_parses(monkeypatch):
             "age_minutes": 12,
             "contract_address": "0x1",
             "deployer": "0xD1",
+            "chain": "solana",
         }
     ]
 


### PR DESCRIPTION
## Summary
- include the originating chain when parsing new tokens
- check new chain field in token fetcher tests
- add unit tests for `is_token_valid`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f39ce36bc832eb150382a36ad4131