### PR TITLE
Add chart configuration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,11 @@ output:
     - "solana_bot_1"
     - "eth_bot_2"
 
+chart:
+  symbol: "bitcoin"               # Asset for the chart
+  vs_currency: "usd"              # Quote currency
+  days: 1                         # Time range in days
+
 scheduler:
   interval_seconds: 300           # Run `main.py` every 5 minutes
 
@@ -209,22 +214,29 @@ python
    import matplotlib.pyplot as plt
    from datetime import datetime
    import os
+   from utils.settings import get_config
 
    BASE_OUTPUT = f"output/{bot_name}"
 
    def generate_and_queue_chart():
        os.makedirs(BASE_OUTPUT, exist_ok=True)
        cg = CoinGeckoAPI()
-       data = cg.get_coin_market_chart_by_id("bitcoin", vs_currency="usd", days=1)
+       config = get_config()
+       chart = config.get("chart", {})
+       data = cg.get_coin_market_chart_by_id(
+           chart.get("symbol", "bitcoin"),
+           vs_currency=chart.get("vs_currency", "usd"),
+           days=chart.get("days", 1),
+       )
        prices = data["prices"]  # [[timestamp, price], ...]
        timestamps = [p[0] for p in prices]
        values = [p[1] for p in prices]
 
        plt.figure(figsize=(6, 4))
        plt.plot(timestamps, values)
-       plt.title("BTC Price Last 24h")
+       plt.title(f"{chart.get('symbol','bitcoin').upper()} Price Last {chart.get('days',1)}d")
        plt.xlabel("Timestamp")
-       plt.ylabel("Price (USD)")
+       plt.ylabel(f"Price ({chart.get('vs_currency','usd').upper()})")
        plt.xticks(rotation=45)
        plt.tight_layout()
 

--- a/config.yaml
+++ b/config.yaml
@@ -29,6 +29,14 @@ output:
     - "eth_bot_2"
 
 # -----------------------------------------
+# Chart settings
+# -----------------------------------------
+chart:
+  symbol: "bitcoin"
+  vs_currency: "usd"
+  days: 1
+
+# -----------------------------------------
 # Content rotation settings
 # -----------------------------------------
 content_cycle:

--- a/generate_content.py
+++ b/generate_content.py
@@ -22,10 +22,18 @@ except Exception:  # pragma: no cover - optional dependency
 
 
 def generate_and_queue_chart(bot_name):
-    """Generate a BTC price chart and queue it for posting."""
-    logger.info(f"[{bot_name}] Generating BTC chart")
+    """Generate a price chart and queue it for posting."""
+    config = get_config()
+    chart_cfg = config.get("chart", {})
+    symbol = chart_cfg.get("symbol", "bitcoin")
+    vs_currency = chart_cfg.get("vs_currency", "usd")
+    days = chart_cfg.get("days", 1)
+
+    logger.info(f"[{bot_name}] Generating {symbol} chart")
     cg = CoinGeckoAPI()
-    data = cg.get_coin_market_chart_by_id("bitcoin", vs_currency="usd", days=1)
+    data = cg.get_coin_market_chart_by_id(
+        symbol, vs_currency=vs_currency, days=days
+    )
     prices = data["prices"]
 
     timestamps = [p[0] for p in prices]
@@ -33,9 +41,9 @@ def generate_and_queue_chart(bot_name):
 
     plt.figure(figsize=(6, 4))
     plt.plot(timestamps, values)
-    plt.title("BTC Price Last 24h")
+    plt.title(f"{symbol.upper()} Price Last {days}d")
     plt.xlabel("Timestamp")
-    plt.ylabel("Price (USD)")
+    plt.ylabel(f"Price ({vs_currency.upper()})")
     plt.xticks(rotation=45)
     plt.tight_layout()
 

--- a/tests/test_generate_functions.py
+++ b/tests/test_generate_functions.py
@@ -136,9 +136,13 @@ def test_generate_and_queue_memecoin_tweet(monkeypatch, tmp_path):
 
 
 def test_generate_and_queue_chart(monkeypatch, tmp_path):
+    captured = {}
+
     class FakeCG:
         def get_coin_market_chart_by_id(self, coin_id, vs_currency="usd", days=1):
-            assert coin_id == "bitcoin"
+            captured["coin_id"] = coin_id
+            captured["vs"] = vs_currency
+            captured["days"] = days
             return {"prices": [[1, 10], [2, 20]]}
 
     class FakePLT:
@@ -175,6 +179,7 @@ def test_generate_and_queue_chart(monkeypatch, tmp_path):
     monkeypatch.setattr(generate_content, "get_output_base_folder", lambda: str(tmp_path))
     monkeypatch.setattr(generate_content, "get_bot_mode", lambda: "post")
     monkeypatch.setattr(generate_content, "has_telegram", lambda: False)
+    monkeypatch.setattr(generate_content, "get_config", lambda: {"chart": {"symbol": "dogecoin", "vs_currency": "eur", "days": 7}})
     monkeypatch.setattr(generate_content, "datetime", DummyDT)
 
     generate_content.generate_and_queue_chart("bot1")
@@ -182,4 +187,5 @@ def test_generate_and_queue_chart(monkeypatch, tmp_path):
     expected = tmp_path / "bot1" / "chart_20230102_0304.png"
     assert fake_plt.saved == str(expected)
     assert (tmp_path / "bot1").is_dir()
+    assert captured == {"coin_id": "dogecoin", "vs": "eur", "days": 7}
 


### PR DESCRIPTION
## Summary
- support custom chart symbol in config
- generate chart based on config parameters
- update tests and docs accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f3d1d8a20832ebb68e51b4071c54d