### PR TITLE
Handle Etherscan connection errors

### DIFF
--- a/reputation_checker.py
+++ b/reputation_checker.py
@@ -23,6 +23,10 @@ def is_token_valid(token: dict, min_reputation_score: Optional[int] = None) -> b
         return False
 
     score = get_deployer_reputation(deployer)
+    if score is None:
+        logger.warning("Could not retrieve deployer reputation, skipping check")
+        return True
+
     logger.info(f"[Reputation] {deployer} scored {score}/10")
 
     if min_reputation_score is None:
@@ -32,7 +36,7 @@ def is_token_valid(token: dict, min_reputation_score: Optional[int] = None) -> b
 
     return score >= min_score
 
-def get_deployer_reputation(address: str) -> int:
+def get_deployer_reputation(address: str) -> Optional[int]:
     """
     Estimates deployer reputation based on number of contracts created.
 
@@ -59,4 +63,4 @@ def get_deployer_reputation(address: str) -> int:
 
     except Exception as e:
         logger.error(f"Failed to retrieve deployer reputation: {e}")
-        return 0
+        return None

--- a/tests/test_reputation_checker.py
+++ b/tests/test_reputation_checker.py
@@ -43,3 +43,25 @@ def test_is_token_valid_checks_eth(monkeypatch):
     token = {"chain": "Ethereum", "deployer": "0xA"}
     assert reputation_checker.is_token_valid(token, min_reputation_score=5)
     assert called == ["0xA"]
+
+
+def test_is_token_valid_skips_on_error(monkeypatch):
+    monkeypatch.setattr(reputation_checker, "get_deployer_reputation", lambda a: None)
+
+    token = {"chain": "Ethereum", "deployer": "0xB"}
+    assert reputation_checker.is_token_valid(token, min_reputation_score=5)
+
+
+def test_get_deployer_reputation_network_error(monkeypatch):
+    class DummyExc(Exception):
+        pass
+
+    def fake_get(*a, **k):
+        raise DummyExc("boom")
+
+    requests_stub = types.ModuleType("requests")
+    requests_stub.get = fake_get
+    monkeypatch.setattr(reputation_checker, "requests", requests_stub)
+
+    rep = reputation_checker.get_deployer_reputation("0xC")
+    assert rep is None


### PR DESCRIPTION
## Summary
- return `None` from `get_deployer_reputation` if the request fails
- treat `None` as unknown in `is_token_valid`
- test behaviour when the API call errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f3ea91be0832ea5c5d624da3d5c85