### PR TITLE
Use cached filters in memecoin tweet generator

### DIFF
--- a/generate_content.py
+++ b/generate_content.py
@@ -13,6 +13,7 @@ from utils.settings import (
     get_output_base_folder,
     has_telegram,
     get_config,
+    get_filters,
 )
 try:
     from telegram_bot import notify_pending  # type: ignore
@@ -82,8 +83,7 @@ def generate_and_queue_memecoin_tweet(bot_name, chain="solana", top_n=3):
     logger.info(f"[{bot_name}] Fetching memecoins on {chain}")
 
     try:
-        config = get_config()
-        filters = config.get("filters", {})
+        filters = get_filters()
     except Exception as e:
         logger.error(
             f"[{bot_name}] Failed to load filters from config.yaml: {e}"

--- a/tests/test_generate_functions.py
+++ b/tests/test_generate_functions.py
@@ -106,7 +106,7 @@ def test_generate_and_queue_memecoin_tweet(monkeypatch, tmp_path):
     monkeypatch.setattr(generate_content, "fetch_new_tokens", lambda c: tokens)
     monkeypatch.setattr(generate_content, "is_token_valid", lambda t, m=None: True)
 
-    monkeypatch.setattr(generate_content, "get_config", lambda: {})
+    monkeypatch.setattr(generate_content, "get_filters", lambda: {})
 
     calls = []
 

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -40,6 +40,13 @@ def get_output_base_folder() -> str:
     cfg = _load_config()
     return cfg.get("output", {}).get("base_folder", "output")
 
+
+def get_filters() -> dict:
+    """Return filtering options from the cached configuration."""
+
+    cfg = _load_config()
+    return cfg.get("filters", {})
+
 def has_telegram() -> bool:
     """Return ``True`` if Telegram credentials are configured."""
 


### PR DESCRIPTION
## Summary
- add `get_filters()` helper in `utils.settings`
- fetch filters via `get_filters()` in content generator
- adjust tests for the new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f3eb1042c832e86cff2a55f5c888b