### PR TITLE
Add pytest cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Python cache
 __pycache__/
+.pytest_cache/
 *.py[cod]
 
 # Env files


### PR DESCRIPTION
## Summary
- ignore `.pytest_cache/` to avoid tracking pytest artifacts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f41ca941c832eb775728a392eea46