### PR TITLE
Add tests for telegram bot and state cycle

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import types
+import json
+
+# Add project root to sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Stub dependencies for main import
+logger_mod = types.ModuleType("logger")
+logger_mod.logger = types.SimpleNamespace(info=lambda *a, **k: None,
+                                          warning=lambda *a, **k: None,
+                                          error=lambda *a, **k: None)
+sys.modules.setdefault("utils.logger", logger_mod)
+
+dotenv_mod = types.ModuleType("dotenv")
+dotenv_mod.load_dotenv = lambda: None
+sys.modules.setdefault("dotenv", dotenv_mod)
+
+settings_mod = types.ModuleType("utils.settings")
+settings_mod.get_config = lambda: {}
+sys.modules.setdefault("utils.settings", settings_mod)
+
+gc_mod = types.ModuleType("generate_content")
+gc_mod.generate_and_queue_chart = lambda *a, **k: None
+gc_mod.generate_and_queue_exchange_info = lambda *a, **k: None
+gc_mod.generate_and_queue_memecoin_tweet = lambda *a, **k: None
+gc_mod.generate_and_queue_comment = lambda *a, **k: None
+sys.modules.setdefault("generate_content", gc_mod)
+
+import main
+
+
+def test_get_next_content_type_updates_state(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    cycle = ["a", "b", "c"]
+
+    first = main.get_next_content_type(cycle)
+    assert first == "a"
+    assert json.loads(open("state.json", encoding="utf-8").read()) == {"index": 1}
+
+    second = main.get_next_content_type(cycle)
+    assert second == "b"
+    assert json.loads(open("state.json", encoding="utf-8").read()) == {"index": 2}
+
+    third = main.get_next_content_type(cycle)
+    assert third == "c"
+    assert json.loads(open("state.json", encoding="utf-8").read()) == {"index": 0}

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -1,0 +1,79 @@
+import os
+import sys
+import types
+import importlib
+
+# Add project root to sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Set env so telegram_bot initializes
+os.environ["TELEGRAM_BOT_TOKEN"] = "token"
+os.environ["TELEGRAM_CHAT_ID"] = "42"
+
+# Stub telegram modules
+sent_messages = []
+
+class DummyBot:
+    def __init__(self, token=None):
+        self.token = token
+    def send_message(self, chat_id, text, reply_markup=None, parse_mode=None):
+        sent_messages.append({
+            "chat_id": chat_id,
+            "text": text,
+            "reply_markup": reply_markup,
+            "parse_mode": parse_mode,
+        })
+
+telegram_mod = types.ModuleType("telegram")
+telegram_mod.Bot = DummyBot
+telegram_mod.InlineKeyboardButton = lambda text, callback_data: {"text": text, "callback_data": callback_data}
+telegram_mod.InlineKeyboardMarkup = lambda kb: {"keyboard": kb}
+telegram_mod.Update = object
+sys.modules.setdefault("telegram", telegram_mod)
+
+telegram_ext_mod = types.ModuleType("telegram.ext")
+telegram_ext_mod.Updater = object
+telegram_ext_mod.CallbackQueryHandler = lambda func: None
+telegram_ext_mod.CallbackContext = object
+sys.modules.setdefault("telegram.ext", telegram_ext_mod)
+
+# Stub dotenv so module imports cleanly
+dotenv_mod = types.ModuleType("dotenv")
+dotenv_mod.load_dotenv = lambda: None
+sys.modules.setdefault("dotenv", dotenv_mod)
+
+import telegram_bot
+importlib.reload(telegram_bot)
+
+
+def test_notify_pending_sends_message():
+    sent_messages.clear()
+    telegram_bot.notify_pending("bot1", "/x/y/post.txt")
+    assert sent_messages
+    msg = sent_messages[0]
+    assert msg["chat_id"] == 42
+    assert "post.txt" in msg["text"]
+    assert "bot1" in msg["text"]
+    kb = msg["reply_markup"]["keyboard"]
+    assert kb[0][0]["callback_data"] == "publish|bot1|post.txt"
+    assert kb[0][1]["callback_data"] == "reject|bot1|post.txt"
+
+
+def test_handle_callback_publish_and_reject(monkeypatch):
+    moves = []
+    deletes = []
+    monkeypatch.setattr(telegram_bot.shutil, "move", lambda s, d: moves.append((s, d)))
+    monkeypatch.setattr(telegram_bot.os, "makedirs", lambda p, exist_ok=False: None)
+    monkeypatch.setattr(telegram_bot.os, "remove", lambda p: deletes.append(p))
+
+    sent_messages.clear()
+    upd = types.SimpleNamespace(callback_query=types.SimpleNamespace(data="publish|bot2|file.txt", answer=lambda: None))
+    telegram_bot.handle_callback(upd, None)
+    assert moves == [(os.path.join("pending", "bot2", "file.txt"), os.path.join("output", "bot2", "file.txt"))]
+    assert "Published" in sent_messages[-1]["text"]
+
+    sent_messages.clear()
+    upd = types.SimpleNamespace(callback_query=types.SimpleNamespace(data="reject|bot2|file.txt", answer=lambda: None))
+    telegram_bot.handle_callback(upd, None)
+    assert deletes == [os.path.join("pending", "bot2", "file.txt")]
+    assert "Rejected" in sent_messages[-1]["text"]


### PR DESCRIPTION
## Summary
- add tests for `notify_pending` and `handle_callback` in `telegram_bot`
- add test ensuring `state.json` drives content cycle in `main`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f4333e164832eadd9f79fcf79c6e4